### PR TITLE
Fix worker thread memory leaks (solves error 2011-0301, threadCreate rc 559)

### DIFF
--- a/ldn_mitm/source/lan_discovery.cpp
+++ b/ldn_mitm/source/lan_discovery.cpp
@@ -471,7 +471,6 @@ void LANDiscovery::worker() {
         svcSleepThread(0);
     }
     LogFormat("Worker exit");
-    svcExitThread();
 }
 
 Result LANDiscovery::getNetworkInfo(NetworkInfo *pOutNetwork) {


### PR DESCRIPTION
The crashes happened due to a memory leak related to the sysmodule's worker threads. When exiting one of the said threads, ldn_mitm erroneously calls svcExitThread before workerThread.Join which makes the latter fail to exit cleanly and free is resources (return code 5977) and that causes the aforementioned leak. After some time, the sysmodule runs out of free memory and, thus, it becomes unable to create new worker threads (threadCreate return code 559, aka LibnxError_OutOfMemory). That's why you must reset the console once it crashes to make it work again.

Unless I misunderstood what the code does, calling svcExitThread shouldn't be needed at all because Join already waits for a thread to be done executing and then terminates it cleanly (in a nutshell, it first calls threadWaitForExit and then threadClose) so all this mod does is it just removes the svcExitThread call - so far, I haven't seen any adverse effects by doing so after around 24 hours of mixed online gameplay/idling, nor any Join/threadCreate errors in the logs. An issue like this wouldn't be limited to Pokémon only and old logs seem to confirm it, however, the crashes likely only popped up now because Pokémon sends a metric crapton of stuff over the network compared to the other Switch games, thus exhausting the available memory more quickly.

(Quoted from my post [here on the temp.](https://gbatemp.net/threads/ldn_mitm-play-local-wireless-supported-games-online.525512/page-13#post-8869147) Other people have reported no issues too since then.)