### PR TITLE
[GHA] Update workflows to use offical dkp docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       prefix: submodule
     schedule:
       interval: daily
+  
+  - directory: /
+    open-pull-requests-limit: 5
+    package-ecosystem: github-actions
+    reviewers:
+      - spacemeowx2
+    commit-message:
+      prefix: gha
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,29 +6,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    container:
+      image: devkitpro/devkita64:latest
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: spacemeowx2/devkitpro-action@v2
-        with:
-          libnx-rev: 5ca15e7696e174c41ee94974d62602fde722ac3b
-          cmd: make -j8
+
+      - name: Build
+        run: make -j8
 
       - name: Upload built files
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: sdcard
           path: out/sd
 
       - name: Upload elf file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ldn_mitm.elf
           path: ldn_mitm/ldn_mitm.elf
 
       - name: Upload elf file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ldn_mitm.elf
           path: overlay/overlay.elf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
       - name: Build
-        run: make -j8
+        run: make -j8 PREFIX="ccache aarch64-none-elf-"
 
       - name: Install libnx master & Retry build
         if: ${{ failure() }}
@@ -27,10 +30,10 @@ jobs:
           pushd /tmp
           git clone https://github.com/switchbrew/libnx
           cd libnx
-          make -j8
+          make -j8 PREFIX="ccache aarch64-none-elf-"
           make install
           popd
-          make -j8
+          make -j8 PREFIX="ccache aarch64-none-elf-"
 
       - name: Upload built files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ jobs:
     container:
       image: devkitpro/devkita64:latest
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -16,6 +20,17 @@ jobs:
 
       - name: Build
         run: make -j8
+
+      - name: Install libnx master & Retry build
+        if: ${{ failure() }}
+        run: |
+          pushd /tmp
+          git clone https://github.com/switchbrew/libnx
+          cd libnx
+          make -j8
+          make install
+          popd
+          make -j8
 
       - name: Upload built files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Build
+        id: build
         run: make -j8 PREFIX="ccache aarch64-none-elf-"
+        continue-on-error: true
 
       - name: Install libnx master & Retry build
-        if: ${{ failure() }}
+        id: retry
+        if: ${{ steps.build.outcome == 'failure' }}
         run: |
           pushd /tmp
           git clone https://github.com/switchbrew/libnx

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,34 +8,38 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    container:
+      image: devkitpro/devkita64:latest
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
+      
       - name: update Atmosphere-libs
         run: |
           pushd Atmosphere-libs
+          git fetch --all
           git reset --hard origin/master
           popd
-      - uses: spacemeowx2/devkitpro-action@v2
-        with:
-          libnx-rev: master
-          cmd: make -j8
+      
+      - name: Build
+        run: make -j8
 
       - name: Upload built files
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: sdcard
           path: out/sd
 
       - name: Upload elf file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ldn_mitm.elf
           path: ldn_mitm/ldn_mitm.elf
 
       - name: Upload elf file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: ldn_mitm.elf
           path: overlay/overlay.elf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,10 +31,13 @@ jobs:
           popd
       
       - name: Build
+        id: build
         run: make -j8 PREFIX="ccache aarch64-none-elf-"
+        continue-on-error: true
 
       - name: Install libnx master & Retry build
-        if: ${{ failure() }}
+        id: retry
+        if: ${{ steps.build.outcome == 'failure' }}
         run: |
           pushd /tmp
           git clone https://github.com/switchbrew/libnx

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,10 @@ jobs:
     container:
       image: devkitpro/devkita64:latest
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,6 +29,17 @@ jobs:
       
       - name: Build
         run: make -j8
+
+      - name: Install libnx master & Retry build
+        if: ${{ failure() }}
+        run: |
+          pushd /tmp
+          git clone https://github.com/switchbrew/libnx
+          cd libnx
+          make -j8
+          make install
+          popd
+          make -j8
 
       - name: Upload built files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
       
       - name: update Atmosphere-libs
         run: |
@@ -28,7 +31,7 @@ jobs:
           popd
       
       - name: Build
-        run: make -j8
+        run: make -j8 PREFIX="ccache aarch64-none-elf-"
 
       - name: Install libnx master & Retry build
         if: ${{ failure() }}
@@ -36,10 +39,10 @@ jobs:
           pushd /tmp
           git clone https://github.com/switchbrew/libnx
           cd libnx
-          make -j8
+          make -j8 PREFIX="ccache aarch64-none-elf-"
           make install
           popd
-          make -j8
+          make -j8 PREFIX="ccache aarch64-none-elf-"
 
       - name: Upload built files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,25 +9,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    container:
+      image: devkitpro/devkita64:latest
+
     steps:
     - name: Set env
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-    - uses: actions/checkout@v1
+      run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: spacemeowx2/devkitpro-action@v2
-      with:
-        libnx-rev: 9865dbf92177c358b88fa7542b628d8a8a2a9d74
-        cmd: make -j8
+    
+    - name: Build
+      run: make -j8
+
     - name: Pack
       run: |
         cd ./out/sd
         sudo zip -r ./ldn_mitm_${{ env.RELEASE_VERSION }}.zip atmosphere switch
+    
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -35,9 +38,10 @@ jobs:
         release_name: ${{ env.RELEASE_VERSION }}
         draft: false
         prerelease: false
+    
     - name: Upload Release Asset
       id: upload-release-asset
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     container:
       image: devkitpro/devkita64:latest
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
@@ -22,6 +26,17 @@ jobs:
     
     - name: Build
       run: make -j8
+    
+    - name: Install libnx master & Retry build
+      if: ${{ failure() }}
+      run: |
+        pushd /tmp
+        git clone https://github.com/switchbrew/libnx
+        cd libnx
+        make -j8
+        make install
+        popd
+        make -j8
 
     - name: Pack
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
     
     - name: Build
-      run: make -j8
+      run: make -j8 PREFIX="ccache aarch64-none-elf-"
     
     - name: Install libnx master & Retry build
       if: ${{ failure() }}
@@ -33,10 +36,10 @@ jobs:
         pushd /tmp
         git clone https://github.com/switchbrew/libnx
         cd libnx
-        make -j8
+        make -j8 PREFIX="ccache aarch64-none-elf-"
         make install
         popd
-        make -j8
+        make -j8 PREFIX="ccache aarch64-none-elf-"
 
     - name: Pack
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,13 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
     
     - name: Build
+      id: build
       run: make -j8 PREFIX="ccache aarch64-none-elf-"
+      continue-on-error: true
     
     - name: Install libnx master & Retry build
-      if: ${{ failure() }}
+      id: retry
+      if: ${{ steps.build.outcome == 'failure' }}
       run: |
         pushd /tmp
         git clone https://github.com/switchbrew/libnx


### PR DESCRIPTION
This PR replaces the custom github action with dkp docker images. When the first build fails, the workflow clones libnx and installs it. After that it tries to build again.

Aside from that I added github actions to dependabot and ccache to speed up subsequent builds.